### PR TITLE
add-flag only handle font/style as block!

### DIFF
--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -79,7 +79,7 @@ system/view/VID: context [
 		]
 		obj: obj/:facet
 		
-		make logic! either blk: obj/:field [
+		make logic! either all [blk: obj/:field facet = 'font field = 'style] [
 			unless block? blk [obj/:field: blk: reduce [blk]]
 			alter blk flag
 		][


### PR DESCRIPTION
To my understanding, only `font/style` facet needs to be handled as a `block!` if several styles words are provided.
No other facet in `font!`, nor `para!` object has to handle more than one value.
With the exception of `/state` and `/parent` maybe, but there are managed by low level code AFAIK, not by VID functions.

It must fixe #2269 and #2380